### PR TITLE
kubevirt-copr: Build on s390x

### DIFF
--- a/kubevirt-copr
+++ b/kubevirt-copr
@@ -28,8 +28,10 @@ PACKAGE_NAMES = [
 CHROOTS = [
     "fedora-32-x86_64",
     "fedora-32-aarch64",
+    "fedora-32-s390x",
     "fedora-33-x86_64",
     "fedora-33-aarch64",
+    "fedora-33-s390x",
 ]
 
 


### PR DESCRIPTION
ppc64le is still MIA, but s390x builds are possible today.