### PR TITLE
kubevirt-copr: Update chroot names for CentOS Stream 8

### DIFF
--- a/kubevirt-copr
+++ b/kubevirt-copr
@@ -31,8 +31,8 @@ CHROOTS = [
     "fedora-32-aarch64",
     "fedora-33-x86_64",
     "fedora-33-aarch64",
-    "centos-stream-x86_64",
-    "centos-stream-aarch64",
+    "centos-stream-8-x86_64",
+    "centos-stream-8-aarch64",
     # emulated s390x builds fail in the qemu test suite
     # they also take over 24 hours to complete.
     # Disable for now


### PR DESCRIPTION
The current names result in

  copr.v3.exceptions.CoprRequestException:
    {'chroots': ["'centos-stream-x86_64' is not a valid
                  choice for this field"]}

Signed-off-by: Andrea Bolognani <abologna@redhat.com>